### PR TITLE
Improve parsing of boolean options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 1.12.1 (unreleased)
 ===================
 
-- Nothing changed yet.
-
+- Fix parsing of use-sudo=false and uniform parsing other boolean options
+  [pgrunewald]
 
 1.12.0 (2021-03-06)
 ===================

--- a/collective/recipe/plonesite/README.rst
+++ b/collective/recipe/plonesite/README.rst
@@ -38,11 +38,13 @@ use-sudo
     Run the task under a different user, as specified in the
     appropriate instance's buildout section. You need to configure
     sudo appropriately.
+    Default: ``false``
 
 add-mountpoint
     Adds the ZODB Mount Point at the path specified by ``container-path``, if
     it doesn't exist. Very handy when used in conjunction with
     collective.recipe.filestorage.
+    Default: ``false``
 
 Logging
 -------
@@ -140,7 +142,7 @@ site-replace
 enabled
     Option to start up the instance/zeoserver. Default: true. This can
     be a useful option from the command line if you do not want to
-    start up Zope, but still want to run the complete buildout.
+    start up Zope, but still want to run the complete buildout. Default: false
 
     $ bin/buildout -Nv plonesite:enabled=false
 


### PR DESCRIPTION
I stumbled upon a problem, where setting the option "use-sudo=false" lead to be interpreted as True. Reason was that it was read as non-empty string ("false"), which yields True.

This PR unifies the boolean options parsing in a similar manner like buildout does it.